### PR TITLE
Rename to llm-text-review

### DIFF
--- a/extention-build.sh
+++ b/extention-build.sh
@@ -1,2 +1,2 @@
 npx vsce package
-ls -al llm-write-review-*.vsix
+ls -al llm-text-review-*.vsix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "llm-write-review",
-	"displayName": "LLM Write Review",
+    "name": "llm-text-review",
+    "displayName": "LLM Text Review",
 	"description": "Local LLM-powered writing review as VS Code diagnostics",
 	"version": "0.0.1",
 	"engines": {
@@ -73,10 +73,10 @@
 		"onLanguage:txt"
 	],
 	"main": "./out/extension.js",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/bulldra/llm-write-review-extension.git"
-	},
+        "repository": {
+                "type": "git",
+                "url": "https://github.com/bulldra/llm-text-review-extension.git"
+        },
 	"scripts": {
 		"watch": "esbuild src/extension.ts --bundle --platform=node --outfile=out/extension.js --format=cjs --sourcemap --watch  --external:vscode",
 		"build": "esbuild src/extension.ts --bundle --platform=node --outfile=out/extension.js --format=cjs --minify --external:vscode"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,11 +11,11 @@ const INCLUDE_PATTERNS =
 	llmWriteEditConfig.get<string[]>('includePatterns') || []
 
 const LLM_REVIEWER_CONSOLE =
-	vscode.window.createOutputChannel('llm-write-review')
+        vscode.window.createOutputChannel('llm-text-review')
 const diagnosticCollection =
-	vscode.languages.createDiagnosticCollection('llm-write-review')
+        vscode.languages.createDiagnosticCollection('llm-text-review')
 
-LLM_REVIEWER_CONSOLE.appendLine('[llm-write-review] 拡張機能が初期化されました')
+LLM_REVIEWER_CONSOLE.appendLine('[llm-text-review] 拡張機能が初期化されました')
 
 function isTextDocument(languageId: string): boolean {
 	const ids = new Set([
@@ -71,9 +71,9 @@ export async function activate(ctx: vscode.ExtensionContext) {
 	const queue = new PQueue({ concurrency: 2 })
 
 	const lintIfNeeded = (doc: vscode.TextDocument) => {
-		LLM_REVIEWER_CONSOLE.appendLine(
-			`[llm-write-review] lintIfNeeded called for ${doc.fileName}`
-		)
+                LLM_REVIEWER_CONSOLE.appendLine(
+                        `[llm-text-review] lintIfNeeded called for ${doc.fileName}`
+                )
 		if (doc.isUntitled) return
 		if (!isTextDocument(doc.languageId)) return
 		if (shouldExclude(doc.uri.fsPath)) {


### PR DESCRIPTION
## Summary
- rename extension naming from `llm-write-review` to `llm-text-review`
- update script to output renamed package

## Testing
- `npm run build` *(fails: esbuild not found)*