### PR TITLE
Add custom instruction file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # llm code review
 
 https://www.du-soleil.com/entry/local-llm-code-reviewer
+
+## Custom Instructions
+
+You can provide additional review instructions by placing a file named `.llm-text-review` in your workspace. The contents of this file will be appended to the review prompt.

--- a/package.json
+++ b/package.json
@@ -37,13 +37,18 @@
 					"default": [],
 					"description": "レビュー対象に含めるファイルパターン（glob形式）。指定した場合は、これらのパターンのみが対象になります。"
 				},
-				"llmWriteEdit.autoReviewOnOpen": {
-					"type": "boolean",
-					"default": true,
-					"description": "ファイルを開いたときに自動レビューを実行するかどうか"
-				}
-			}
-		},
+                                "llmWriteEdit.autoReviewOnOpen": {
+                                        "type": "boolean",
+                                        "default": true,
+                                        "description": "ファイルを開いたときに自動レビューを実行するかどうか"
+                                },
+                                "llmWriteEdit.customInstructionFile": {
+                                        "type": "string",
+                                        "default": ".llm-text-review",
+                                        "description": "カスタムインストラクションファイルへのパス"
+                                }
+                        }
+                },
 		"commands": [
 			{
 				"command": "llmWriteEdit.reviewCurrentFile",


### PR DESCRIPTION
## Summary
- set default config `llmWriteEdit.customInstructionFile` to `.llm-text-review`
- document how to use a custom instruction file

## Testing
- `npm run build` *(fails: `esbuild: not found`)*