### PR TITLE
Refactor extension utilities

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 import { requestLLMReviewWithFunctionCalling, LLM_CONFIG } from './llm-client'
+import { isTextDocument, shouldExclude } from './utils'
 
 const lastRunMap = new Map<string, number>()
 
@@ -17,54 +18,6 @@ const diagnosticCollection =
 
 LLM_REVIEWER_CONSOLE.appendLine('[llm-text-review] 拡張機能が初期化されました')
 
-function isTextDocument(languageId: string): boolean {
-	const ids = new Set([
-		'markdown',
-		'plaintext',
-		'latex',
-		'tex',
-		'rst',
-		'org',
-		'md',
-		'txt',
-	])
-	return ids.has(languageId)
-}
-
-function shouldExclude(fsPath: string): boolean {
-	const { relative } = require('path')
-	const { minimatch } = require('minimatch')
-	const workspaceFolders = vscode.workspace.workspaceFolders
-	if (!workspaceFolders || workspaceFolders.length === 0) {
-		return false
-	}
-	let relativePath: string | null = null
-	for (const folder of workspaceFolders) {
-		const folderPath = folder.uri.fsPath
-		if (fsPath.startsWith(folderPath)) {
-			relativePath = relative(folderPath, fsPath)
-			break
-		}
-	}
-
-	if (relativePath === null) {
-		return false
-	}
-
-	relativePath = relativePath.replace(/\\/g, '/')
-	if (INCLUDE_PATTERNS.length > 0) {
-		const included = INCLUDE_PATTERNS.some((pattern) =>
-			minimatch(relativePath!, pattern, { dot: true, matchBase: true })
-		)
-		if (!included) {
-			return true
-		}
-	}
-
-	return EXCLUDE_PATTERNS.some((pattern) =>
-		minimatch(relativePath!, pattern, { dot: true, matchBase: true })
-	)
-}
 
 export async function activate(ctx: vscode.ExtensionContext) {
 	const { default: PQueue } = await import('p-queue')
@@ -76,7 +29,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
                 )
 		if (doc.isUntitled) return
 		if (!isTextDocument(doc.languageId)) return
-		if (shouldExclude(doc.uri.fsPath)) {
+                if (shouldExclude(doc.uri.fsPath, EXCLUDE_PATTERNS, INCLUDE_PATTERNS)) {
 			return
 		}
 		queue.add(
@@ -112,7 +65,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
 				return
 			}
 
-			if (shouldExclude(doc.uri.fsPath)) {
+                        if (shouldExclude(doc.uri.fsPath, EXCLUDE_PATTERNS, INCLUDE_PATTERNS)) {
 				return
 			}
 
@@ -244,9 +197,8 @@ function updateDiagnostics(doc: vscode.TextDocument, reviewText: string): void {
 }
 
 async function lintDocument(doc: vscode.TextDocument): Promise<void> {
-	const uriString = doc.uri.toString()
-	const filePath = doc.fileName
-	const now = Date.now()
+        const uriString = doc.uri.toString()
+        const now = Date.now()
 	const last = lastRunMap.get(uriString) ?? 0
 	if (now - last < 30000) {
 		return

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,58 @@
+import * as vscode from 'vscode'
+import { relative } from 'path'
+import { minimatch } from 'minimatch'
+
+export const TEXT_DOCUMENT_LANGUAGE_IDS = new Set([
+    'markdown',
+    'plaintext',
+    'latex',
+    'tex',
+    'rst',
+    'org',
+    'md',
+    'txt',
+])
+
+export function isTextDocument(languageId: string): boolean {
+    return TEXT_DOCUMENT_LANGUAGE_IDS.has(languageId)
+}
+
+export function getRelativePath(fsPath: string): string | null {
+    const folders = vscode.workspace.workspaceFolders
+    if (!folders || folders.length === 0) {
+        return null
+    }
+
+    for (const folder of folders) {
+        const folderPath = folder.uri.fsPath
+        if (fsPath.startsWith(folderPath)) {
+            return relative(folderPath, fsPath).replace(/\\/g, '/')
+        }
+    }
+
+    return null
+}
+
+export function shouldExclude(
+    fsPath: string,
+    excludePatterns: string[],
+    includePatterns: string[],
+): boolean {
+    const relativePath = getRelativePath(fsPath)
+    if (!relativePath) {
+        return false
+    }
+
+    if (includePatterns.length > 0) {
+        const included = includePatterns.some((pattern) =>
+            minimatch(relativePath, pattern, { dot: true, matchBase: true })
+        )
+        if (!included) {
+            return true
+        }
+    }
+
+    return excludePatterns.some((pattern) =>
+        minimatch(relativePath, pattern, { dot: true, matchBase: true })
+    )
+}


### PR DESCRIPTION
## Summary
- factor out helper functions to src/utils.ts
- use new helpers in extension

## Testing
- `npm ci` *(fails: Exit handler never called)*
- `npm run build` *(fails: esbuild not found)*
- `npx tsc --noEmit` *(fails: Cannot find type definition file)*